### PR TITLE
Add ability to get package list from a JSON manifest.

### DIFF
--- a/planb.xcodeproj/project.pbxproj
+++ b/planb.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		490A51ED18D7765500DA939E /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 490A51EC18D7765500DA939E /* main.m */; };
 		490A51EF18D7769200DA939E /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 490A51EE18D7769200DA939E /* Security.framework */; };
 		490A51F218D77D2400DA939E /* PBPackageInstaller.m in Sources */ = {isa = PBXBuildFile; fileRef = 490A51F118D77D2400DA939E /* PBPackageInstaller.m */; };
+		81AAFF57217100B5003E34A4 /* PBManifest.m in Sources */ = {isa = PBXBuildFile; fileRef = 81AAFF56217100B5003E34A4 /* PBManifest.m */; };
 		E8D16F74B748B8590CBAF427 /* libPods-planb.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C2E5CED56076D8EF8C6C6A07 /* libPods-planb.a */; };
 /* End PBXBuildFile section */
 
@@ -40,6 +41,8 @@
 		490A51F018D77D2400DA939E /* PBPackageInstaller.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PBPackageInstaller.h; sourceTree = "<group>"; };
 		490A51F118D77D2400DA939E /* PBPackageInstaller.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PBPackageInstaller.m; sourceTree = "<group>"; };
 		49B3480D1A02CAA800F4FE84 /* PBLogging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PBLogging.h; sourceTree = "<group>"; };
+		81AAFF55217100B5003E34A4 /* PBManifest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PBManifest.h; sourceTree = "<group>"; };
+		81AAFF56217100B5003E34A4 /* PBManifest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PBManifest.m; sourceTree = "<group>"; };
 		C2E5CED56076D8EF8C6C6A07 /* libPods-planb.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-planb.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -94,6 +97,8 @@
 				49B3480D1A02CAA800F4FE84 /* PBLogging.h */,
 				490A51F018D77D2400DA939E /* PBPackageInstaller.h */,
 				490A51F118D77D2400DA939E /* PBPackageInstaller.m */,
+				81AAFF55217100B5003E34A4 /* PBManifest.h */,
+				81AAFF56217100B5003E34A4 /* PBManifest.m */,
 				0D789FD819461AC50036F7C4 /* roots.pem */,
 				490A51E118D7581B00DA939E /* Supporting Files */,
 			);
@@ -128,7 +133,6 @@
 				490A51D518D7581B00DA939E /* Sources */,
 				490A51D618D7581B00DA939E /* Frameworks */,
 				490A51D718D7581B00DA939E /* CopyFiles */,
-				450FBE8FE0A109E05DC9E5CD /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -145,7 +149,7 @@
 		490A51D118D7581B00DA939E /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0820;
+				LastUpgradeCheck = 0940;
 			};
 			buildConfigurationList = 490A51D418D7581B00DA939E /* Build configuration list for PBXProject "planb" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -181,34 +185,22 @@
 			shellPath = /bin/sh;
 			shellScript = "cp \"${SRCROOT}\"/planb/roots.pem ${DERIVED_FILE_DIR}/ROOTS.PEM\n\ncd ${DERIVED_FILE_DIR}\n\n# Remove comments\nsed -i '' -e '/^#.*/d' ROOTS.PEM\n\n# Remove empty lines\nsed -i '' -e '/^$/d' ROOTS.PEM\n\nxxd -i ROOTS.PEM > roots.pem.h\n\nrm ROOTS.PEM";
 		};
-		450FBE8FE0A109E05DC9E5CD /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-planb/Pods-planb-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		8563872E9418485E04F5F70B /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
 			);
 			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-planb-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -218,6 +210,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				81AAFF57217100B5003E34A4 /* PBManifest.m in Sources */,
 				490A51ED18D7765500DA939E /* main.m in Sources */,
 				0D6D8EAE1EEEF53400B93029 /* PBCommandController.m in Sources */,
 				490A51F218D77D2400DA939E /* PBPackageInstaller.m in Sources */,
@@ -235,14 +228,22 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
@@ -279,14 +280,22 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
@@ -313,6 +322,7 @@
 			baseConfigurationReference = 1FFD8688FFB22014A92F8D11 /* Pods-planb.debug.xcconfig */;
 			buildSettings = {
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				VALID_ARCHS = x86_64;
 			};
@@ -323,6 +333,7 @@
 			baseConfigurationReference = 39BB32E66CD18153F1F3AB32 /* Pods-planb.release.xcconfig */;
 			buildSettings = {
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				VALID_ARCHS = x86_64;
 			};

--- a/planb/PBManifest.h
+++ b/planb/PBManifest.h
@@ -1,0 +1,42 @@
+/*
+ Copyright 2018 Google Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ use this file except in compliance with the License.  You may obtain a copy
+ of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ License for the specific language governing permissions and limitations under
+ the License.
+ */
+
+@import Foundation;
+
+/// PBManifest handles downloading and parsing a list of packages to fetch and install.
+@interface PBManifest : NSObject
+
+- (instancetype)init NS_UNAVAILABLE;
+
+/// Designated initializer.
+- (instancetype)initWithURL:(NSURL *)manifestURL NS_DESIGNATED_INITIALIZER;
+
+/// Download and parse the manifest.
+- (void)downloadManifest;
+
+/// Return list of packages in the manifest for the given track.
+- (NSArray *)packagesForTrack:(NSString *)track;
+
+/// The NSURLSession to use for downloading packages. If not set, a default one will be used.
+@property NSURLSession *session;
+
+/// The number of seconds to allow downloading before timing out. Defaults to 300 (5 minutes).
+@property NSUInteger downloadTimeoutSeconds;
+
+/// The number of download attempts before giving up. Defaults to 5.
+@property NSUInteger downloadAttemptsMax;
+
+@end

--- a/planb/PBManifest.h
+++ b/planb/PBManifest.h
@@ -34,6 +34,8 @@
 @property NSURLSession *session;
 
 /// The number of seconds to allow downloading before timing out. Defaults to 300 (5 minutes).
+/// TODO(nguyenphillip): use session config's timeoutIntervalForResource to handle timeouts, and
+/// make session a required argument of initializer for both PBManifest and PBPackageInstaller.
 @property NSUInteger downloadTimeoutSeconds;
 
 /// The number of download attempts before giving up. Defaults to 5.

--- a/planb/PBManifest.h
+++ b/planb/PBManifest.h
@@ -12,7 +12,7 @@
  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
  License for the specific language governing permissions and limitations under
  the License.
- */
+*/
 
 @import Foundation;
 
@@ -27,8 +27,10 @@
 /// Download and parse the manifest.
 - (void)downloadManifest;
 
-/// Return list of packages in the manifest for the given track.
-- (NSArray *)packagesForTrack:(NSString *)track;
+/// Return list of packages in the manifest for the given track.  The path in baseURL is prepended
+/// to each relative package URL specified in the manifest.  Each package item is represented as
+/// an NSArray having the form @[<package-id>, <absolute-URL-to-package>, <SHA256>]
+- (NSArray *)packagesForTrack:(NSString *)track relativeToURL:(NSURL *)baseURL;
 
 /// The NSURLSession to use for downloading packages. If not set, a default one will be used.
 @property NSURLSession *session;

--- a/planb/PBManifest.m
+++ b/planb/PBManifest.m
@@ -98,7 +98,11 @@ static NSString * const kSHA256Key = @"sha256";
     return NO;
   }
   // Validate the manifest data which should have the form:
-  // {"track1": [ {"key1": "val1", "key2": "val2", ...}, ... ], ...}
+  // {"packages": [ <pkg1>, <pkg2>, ...]}
+  // Each package object in the list should have the form:
+  // {"name":"xxx", "package_id":"xxx", "tracks":{"aaa": <fileobj>, "bbb": <fileobj>, ...}}
+  // Each file object value in the tracks dict should have the form:
+  // {"filename":"xxx", "sha256":"xxx"} where the "sha256" key is optional.
   if (![jsonObject isKindOfClass:[NSDictionary class]]) {
     PBLog(@"Invalid manifest -- root object is not a dictionary");
     return NO;

--- a/planb/PBManifest.m
+++ b/planb/PBManifest.m
@@ -1,0 +1,141 @@
+/*
+ Copyright 2018 Google Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ use this file except in compliance with the License.  You may obtain a copy
+ of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ License for the specific language governing permissions and limitations under
+ the License.
+ */
+
+#import <CommonCrypto/CommonDigest.h>
+
+#import "PBManifest.h"
+
+#import "PBLogging.h"
+
+static NSString *const kNameKey = @"name";
+static NSString *const kURLKey = @"url";
+static NSString *const kSHA256Key = @"sha256";
+
+@interface PBManifest()
+
+/// The URL to download the package manifest from.
+@property(readonly, nonatomic, copy) NSURL *manifestURL;
+
+/// The parsed manifest data.
+@property(nonatomic) NSDictionary *manifest;
+
+@end
+
+@implementation PBManifest
+
+- (instancetype)initWithURL:(NSURL *)manifestURL {
+  if (!manifestURL.absoluteString.length) {
+    return nil;
+  }
+  self = [super init];
+  if (self) {
+    _manifestURL = [manifestURL copy];
+    _downloadAttemptsMax = 5;
+    _downloadTimeoutSeconds = 300;
+    _session = [NSURLSession sharedSession];
+  }
+  return self;
+}
+
+- (void)downloadManifest {
+  __block NSData *jsonData;
+  __block NSString *errorDescription;
+
+  for (NSUInteger i = 1; i <= self.downloadAttemptsMax; ++i) {
+    PBLog(@"Downloading manifest, attempt %tu/%tu", i, self.downloadAttemptsMax);
+
+    dispatch_semaphore_t sema = dispatch_semaphore_create(0);
+    [[self.session dataTaskWithURL:self.manifestURL completionHandler:^(NSData *data,
+                                                                        NSURLResponse *response,
+                                                                        NSError *error) {
+      if (((NSHTTPURLResponse *)response).statusCode == 200) {
+        jsonData = data;
+      } else {
+        errorDescription = error.localizedDescription;
+      }
+      dispatch_semaphore_signal(sema);
+    }] resume];
+    dispatch_semaphore_wait(sema, dispatch_time(DISPATCH_TIME_NOW,
+                                                self.downloadTimeoutSeconds * NSEC_PER_SEC));
+
+    if (jsonData) {
+      break;
+    } else if (errorDescription) {
+      PBLog(@"Download of manifest failed: %@", errorDescription);
+    }
+  }
+
+  if (jsonData) {
+    [self parseManifestData:jsonData];
+  }
+}
+
+- (void)parseManifestData:(NSData *)data {
+  NSError *error;
+  id jsonObject = [NSJSONSerialization JSONObjectWithData:data options:0 error:&error];
+  if (error) {
+    PBLog(@"Error parsing manifest: %@", error.localizedDescription);
+    return;
+  }
+  // Validate the manifest data which should have the form:
+  // {"track1": [ {"key1": "val1", "key2": "val2", ...}, ... ], ...}
+  if (![jsonObject isKindOfClass:[NSDictionary class]]) {
+    PBLog(@"Invalid manifest -- root object is not a dictionary");
+    return;
+  }
+  NSDictionary *manifest = (NSDictionary *)jsonObject;
+  for (id track in manifest) {
+    if (![track isKindOfClass:[NSString class]]) {
+      PBLog(@"Invalid manifest -- track key is not a string: %@", track);
+      return;
+    }
+    if (![manifest[track] isKindOfClass:[NSDictionary class]]) {
+      PBLog(@"Invalid manifest -- track %@ value is not a dictionary: %@", track, manifest[track]);
+      return;
+    }
+    NSDictionary *package = (NSDictionary *)manifest[track];
+    for (id key in package) {
+      if (![key isKindOfClass:[NSString class]]) {
+        PBLog(@"Invalid manifest -- package key is not a string: %@", key);
+        return;
+      }
+      if (![package[key] isKindOfClass:[NSString class]]) {
+        PBLog(@"Invalid manifest -- package key %@ value is not a string: %@", key, package[key]);
+        return;
+      }
+    }
+  }
+  self.manifest = (NSDictionary *)jsonObject;
+}
+
+- (NSArray *)packagesForTrack:(NSString *)track {
+  if (!self.manifest) {
+    return @[];
+  }
+  NSMutableArray *result = [NSMutableArray array];
+  for (NSDictionary *package in self.manifest[track]) {
+    if (!package[kURLKey]) continue;
+    if (!package[kNameKey]) continue;
+    if (package[kSHA256Key]) {
+      [result addObject:@[package[kURLKey], package[kNameKey], package[kSHA256Key]]];
+    } else {
+      [result addObject:@[package[kURLKey], package[kNameKey]]];
+    }
+  }
+  return result;
+}
+
+@end

--- a/planb/PBManifest.m
+++ b/planb/PBManifest.m
@@ -27,7 +27,7 @@ static NSString * const kSHA256Key = @"sha256";
 @interface PBManifest()
 
 /// The URL to download the package manifest from.
-@property(readonly, nonatomic, copy) NSURL *manifestURL;
+@property(readonly, nonatomic) NSURL *manifestURL;
 
 /// The parsed manifest data.
 @property(nonatomic) NSDictionary *manifest;
@@ -61,9 +61,11 @@ static NSString * const kSHA256Key = @"sha256";
     [[self.session dataTaskWithURL:self.manifestURL completionHandler:^(NSData *data,
                                                                         NSURLResponse *response,
                                                                         NSError *error) {
-      if (((NSHTTPURLResponse *)response).statusCode == 200) {
+      if (![response isKindOfClass:[NSHTTPURLResponse class]] ||
+          ((NSHTTPURLResponse *)response).statusCode == 200) {
         jsonData = data;
-      } else {
+      }
+      if (error) {
         errorDescription = error.localizedDescription;
       }
       dispatch_semaphore_signal(sema);
@@ -88,7 +90,7 @@ static NSString * const kSHA256Key = @"sha256";
 - (void)parseManifestData:(NSData *)data {
   NSError *error;
   id jsonObject = [NSJSONSerialization JSONObjectWithData:data options:0 error:&error];
-  if (error) {
+  if (!jsonObject) {
     PBLog(@"Error parsing manifest: %@", error.localizedDescription);
     return;
   }

--- a/planb/PBManifest.m
+++ b/planb/PBManifest.m
@@ -140,8 +140,14 @@ static NSString * const kSHA256Key = @"sha256";
   }
   NSMutableArray *result = [NSMutableArray array];
   for (NSDictionary *package in self.manifest[track]) {
-    if (!package[kURLKey]) continue;
-    if (!package[kNameKey]) continue;
+    if (!package[kURLKey]) {
+      PBLog(@"Manifest item is missing %@ key, skipping: %@", kURLKey, package);
+      continue;
+    }
+    if (!package[kNameKey]) {
+      PBLog(@"Manifest item is missing %@ key, skipping: %@", kNameKey, package);
+      continue;
+    }
     if (package[kSHA256Key]) {
       [result addObject:@[package[kURLKey], package[kNameKey], package[kSHA256Key]]];
     } else {

--- a/planb/PBPackageInstaller.h
+++ b/planb/PBPackageInstaller.h
@@ -24,7 +24,8 @@
 
 /// Designated initializer.
 - (instancetype)initWithURL:(NSURL *)packageURL
-                receiptName:(NSString *)receipt NS_DESIGNATED_INITIALIZER;
+                receiptName:(NSString *)receipt
+                   checksum:(NSString *)checksum NS_DESIGNATED_INITIALIZER;
 
 /// The NSURLSession to use for downloading packages. If not set, a default one will be used.
 @property NSURLSession *session;

--- a/planb/PBPackageInstaller.m
+++ b/planb/PBPackageInstaller.m
@@ -165,7 +165,7 @@ static NSString *const kPkgutilPath = @"/usr/sbin/pkgutil";
   NSString *checksum = [self SHA256ForFileAtPath:path];
   [self log:@"Package SHA-256: %@", checksum];
   if (self.checksum.length && ![self.checksum isEqualToString:checksum]) {
-    [self log:@"Checksum doesn't match expected (%@), deleting...", self.checksum];
+    [self log:@"Error: checksum doesn't match expected (%@), deleting...", self.checksum];
     NSFileManager *fm = [NSFileManager defaultManager];
     NSError *error;
     if (![fm removeItemAtPath:path error:&error]) {

--- a/planb/PBPackageInstaller.m
+++ b/planb/PBPackageInstaller.m
@@ -31,8 +31,11 @@ static NSString *const kPkgutilPath = @"/usr/sbin/pkgutil";
 /// Package receipt name, e.g. 'com.megacorp.corp.pkg'.
 @property(readonly, nonatomic, copy) NSString *receiptName;
 
-/// The URL to downlaod the package from.
+/// The URL to download the package from.
 @property(readonly, nonatomic, copy) NSURL *packageURL;
+
+/// Checksum of downloaded package for verification.
+@property(readonly, nonatomic, copy) NSString *checksum;
 
 /// Path to mounted disk image, e.g. '/tmp/planb-pkg.duc3eP'.
 @property(readonly, nonatomic, copy) NSString *mountPoint;
@@ -42,7 +45,8 @@ static NSString *const kPkgutilPath = @"/usr/sbin/pkgutil";
 @implementation PBPackageInstaller
 
 - (instancetype)initWithURL:(NSURL *)packageURL
-                receiptName:(NSString *)receipt {
+                receiptName:(NSString *)receipt
+                   checksum:(NSString *)checksum {
   self = [super init];
 
   if (self) {
@@ -52,6 +56,7 @@ static NSString *const kPkgutilPath = @"/usr/sbin/pkgutil";
 
     _receiptName = [receipt copy];
     _packageURL = [packageURL copy];
+    _checksum = [checksum copy];
     _mountPoint = [self generateMountPoint];
 
     _downloadAttemptsMax = 5;
@@ -145,7 +150,8 @@ static NSString *const kPkgutilPath = @"/usr/sbin/pkgutil";
                                                 self.downloadTimeoutSeconds * NSEC_PER_SEC));
 
     if (path) {
-      [self log:@"Download complete, SHA-1: %@", [self SHA1ForFileAtPath:path]];
+      [self log:@"Download complete"];
+      [self validatePackage:path];
       break;
     } else if (errorDescription) {
       [self log:@"Download failed: %@", errorDescription];
@@ -153,6 +159,19 @@ static NSString *const kPkgutilPath = @"/usr/sbin/pkgutil";
   }
 
   return path;
+}
+
+- (void)validatePackage:(NSString *)path {
+  NSString *checksum = [self SHA256ForFileAtPath:path];
+  [self log:@"Package SHA-256: %@", checksum];
+  if (self.checksum.length && ![self.checksum isEqualToString:checksum]) {
+    [self log:@"Checksum doesn't match expected (%@), deleting...", self.checksum];
+    NSFileManager *fm = [NSFileManager defaultManager];
+    NSError *error;
+    if (![fm removeItemAtPath:path error:&error]) {
+      [self log:@"Error: could not remove %@: %@", path, error];
+    }
+  }
 }
 
 - (BOOL)diskImageAttach:(NSString *)path {
@@ -206,17 +225,17 @@ static NSString *const kPkgutilPath = @"/usr/sbin/pkgutil";
   [t launchWithOutput:NULL];
 }
 
-- (NSString *)SHA1ForFileAtPath:(NSString *)path {
-  unsigned char sha1[CC_SHA1_DIGEST_LENGTH];
+- (NSString *)SHA256ForFileAtPath:(NSString *)path {
+  unsigned char checksum[CC_SHA256_DIGEST_LENGTH];
   NSData *fileData = [NSData dataWithContentsOfFile:path
                                             options:NSDataReadingMappedIfSafe
                                               error:nil];
 
-  CC_SHA1(fileData.bytes, (CC_LONG)fileData.length, sha1);
-  NSMutableString *buf = [[NSMutableString alloc] initWithCapacity:CC_SHA1_DIGEST_LENGTH * 2];
+  CC_SHA256(fileData.bytes, (CC_LONG)fileData.length, checksum);
+  NSMutableString *buf = [[NSMutableString alloc] initWithCapacity:CC_SHA256_DIGEST_LENGTH * 2];
 
-  for (int i = 0; i < CC_SHA1_DIGEST_LENGTH; i++) {
-    [buf appendFormat:@"%02x", sha1[i]];
+  for (int i = 0; i < CC_SHA256_DIGEST_LENGTH; i++) {
+    [buf appendFormat:@"%02x", checksum[i]];
   }
 
   return buf;

--- a/planb/PBPackageInstaller.m
+++ b/planb/PBPackageInstaller.m
@@ -139,9 +139,11 @@ static NSString *const kPkgutilPath = @"/usr/sbin/pkgutil";
     [[self.session downloadTaskWithURL:self.packageURL completionHandler:^(NSURL *location,
                                                                            NSURLResponse *response,
                                                                            NSError *error) {
-      if (((NSHTTPURLResponse *)response).statusCode == 200) {
+      if (![response isKindOfClass:[NSHTTPURLResponse class]] ||
+          ((NSHTTPURLResponse *)response).statusCode == 200) {
         path = location.path;
-      } else {
+      }
+      if (error) {
         errorDescription = error.localizedDescription;
       }
       dispatch_semaphore_signal(sema);

--- a/planb/main.m
+++ b/planb/main.m
@@ -26,7 +26,7 @@
 #import <MOLAuthenticatingURLSession/MOLAuthenticatingURLSession.h>
 
 static NSString * const kBaseURL = @"https://mac.internal.megacorp.com/pkgs/";
-static NSString * const kManifestURL = @"https://mac.internal.megacorp.com/manifest";
+static NSString * const kManifestURL = @"https://mac.internal.megacorp.com/manifest.json";
 static NSString * const kMachineInfo = @"/Library/Preferences/com.megacorp.machineinfo.plist";
 static NSString * const kMachineInfoKey = @"ConfigurationTrack";
 static NSString * const kAssertionName = @"planb";

--- a/planb/main.m
+++ b/planb/main.m
@@ -20,24 +20,43 @@
 #include "roots.pem.h"
 
 #import "PBLogging.h"
+#import "PBManifest.h"
 #import "PBPackageInstaller.h"
 
 #import <MOLAuthenticatingURLSession/MOLAuthenticatingURLSession.h>
 
 static NSString * const kBaseURL = @"https://mac.internal.megacorp.com/pkgs/";
+static NSString * const kManifestURL = @"https://mac.internal.megacorp.com/manifest";
 static NSString * const kMachineInfo = @"/Library/Preferences/com.megacorp.machineinfo.plist";
 static NSString * const kMachineInfoKey = @"ConfigurationTrack";
 static NSString * const kAssertionName = @"planb";
 
 /**
-  Return the list of packages to install, along with their receipt names.
+  Return the list of hard-coded packages to install, along with their receipt names, and
+  optional SHA-256 checksums to be verified.
 */
-NSArray* Packages() {
+NSArray* StaticPackages() {
   return @[
       @[ @"pkg1/package1", @"com.megacorp.package1" ],
       @[ @"pkg2/package2", @"com.megacorp.package2" ],
       @[ @"pkg3/package3", @"com.megacorp.package3" ],
   ];
+}
+
+/**
+  Return the machine's track, read from the property list specified above. Defaults to "stable".
+ */
+NSString *MachineTrack() {
+  static dispatch_once_t onceToken;
+  static NSString *track;
+
+  dispatch_once(&onceToken, ^{
+    NSDictionary *machineInfoDictionary = [NSDictionary dictionaryWithContentsOfFile:kMachineInfo];
+    track = [[machineInfoDictionary objectForKey:kMachineInfoKey] lowercaseString];
+    if (!track.length) track = @"stable";
+  });
+
+  return track;
 }
 
 /**
@@ -50,18 +69,32 @@ NSArray* Packages() {
   E.g. using the default parameters above with the parameter 'pkg1/sample' the URL would be:
   https://mac.internal.megacorp.com/pkgbase/pkg1/sample-stable.dmg
 */
-NSURL* URLForPackagePath(NSString *pkg) {
-  static dispatch_once_t onceToken;
-  static NSString *track;
+NSString* StringURLForPackagePath(NSString *pkg) {
+  NSString *path = [NSString stringWithFormat:@"%@-%@.dmg", pkg, MachineTrack()];
+  NSURL *url = [NSURL URLWithString:path relativeToURL:[NSURL URLWithString:kBaseURL]];
+  return [url absoluteString];
+}
 
-  dispatch_once(&onceToken, ^{
-    NSDictionary *machineInfoDictionary = [NSDictionary dictionaryWithContentsOfFile:kMachineInfo];
-    track = [[machineInfoDictionary objectForKey:kMachineInfoKey] lowercaseString];
-    if (!track.length) track = @"stable";
-  });
+/**
+ Return the list of packages to install, both static and from a downloaded manifest.
+ */
+NSArray* Packages(NSURLSession *session) {
+  NSMutableArray *result = [NSMutableArray array];
 
-  NSString *path = [NSString stringWithFormat:@"%@-%@.dmg", pkg, track];
-  return [NSURL URLWithString:path relativeToURL:[NSURL URLWithString:kBaseURL]];
+  for (NSArray *item in StaticPackages()) {
+    NSMutableArray *newItem = [NSMutableArray arrayWithArray:item];
+    newItem[0] = StringURLForPackagePath(item[0]);
+    [result addObject:newItem];
+  }
+
+  if (kManifestURL.length) {
+    PBManifest *manifest = [[PBManifest alloc] initWithURL:[NSURL URLWithString:kManifestURL]];
+    if (session) manifest.session = session;
+    [manifest downloadManifest];
+    [result addObjectsFromArray:[manifest packagesForTrack:MachineTrack()]];
+  }
+
+  return result;
 }
 
 /**
@@ -105,14 +138,16 @@ int main(int argc, const char **argv) {
     };
 
     __block BOOL success = YES;
-    NSArray *packages = Packages();
-    [packages enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
-      NSString *packagePath = [obj firstObject];
-      NSString *receiptName = [obj lastObject];
+    NSArray *packages = Packages(authURLSession.session);
+    [packages enumerateObjectsUsingBlock:^(NSArray* obj, NSUInteger idx, BOOL *stop) {
+      NSString *packagePath = obj[0];
+      NSString *receiptName = obj[1];
+      NSString *checksum = obj.count >= 3 ? obj[2] : nil;
 
       PBPackageInstaller *pkgInstaller =
-          [[PBPackageInstaller alloc] initWithURL:URLForPackagePath(packagePath)
-                                      receiptName:receiptName];
+          [[PBPackageInstaller alloc] initWithURL:[NSURL URLWithString:packagePath]
+                                      receiptName:receiptName
+                                         checksum:checksum];
       pkgInstaller.logPrefix =
           [NSString stringWithFormat:@"[%lu/%lu %@]",
               (unsigned long)idx + 1, (unsigned long)packages.count, receiptName];

--- a/planb/main.m
+++ b/planb/main.m
@@ -91,7 +91,8 @@ NSArray* Packages(NSURLSession *session) {
     PBManifest *manifest = [[PBManifest alloc] initWithURL:[NSURL URLWithString:kManifestURL]];
     if (session) manifest.session = session;
     [manifest downloadManifest];
-    [result addObjectsFromArray:[manifest packagesForTrack:MachineTrack()]];
+    NSURL *baseURL = [NSURL URLWithString:kBaseURL];
+    [result addObjectsFromArray:[manifest packagesForTrack:MachineTrack() relativeToURL:baseURL]];
   }
 
   return result;


### PR DESCRIPTION
Added kManifestURL constant.  If non-empty then try to download and add packages specified there to the list of hardcoded packages that will be downloaded.  The JSON manifest has the form

```
{
  "unstable" : [
    { "name" : "com.megacorp.package1",
      "url" : "https://mac.internal.megacorp.com/pkgs/package1-unstable.dmg",
      "sha256" : "d2bf2eb4ec0c6534e32b923f2d6990ef636450866a275e17afc5a85769315bf3"
    },
    { "name" : "com.megacorp.package2",
      "url" : "https://mac.internal.megacorp.com/pkgs/package2-unstable.dmg",
      "sha256" : "c434045508044d8cc43a9593f5451bc947ad1d810b4f319a60a684825674ae87",
    }
  ],
  "stable" : [
    { "name" : "com.megacorp.package1",
      "url" : "https://mac.internal.megacorp.com/pkgs/package1-stable.dmg",
      "sha256" : "2b92ea252be0fbc26f70317cdaa7b6411ea634b50d55338cd8c495e4dbf25d1d"
    }
  ]
}
```

The checksums are optional (and can also be added to hardcoded packages).  If present, the downloaded package will be verified against the given checksum before being installed.