### PR TITLE
Add more error detail in PBManifest.m

### DIFF
--- a/planb/PBManifest.m
+++ b/planb/PBManifest.m
@@ -70,7 +70,13 @@ static NSString * const kPlanBIgnoreKey = @"planb_ignore";
         jsonData = data;
       }
       if (error) {
-        errorDescription = error.localizedDescription;
+        if (data) {
+          NSString *body = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+          errorDescription =
+              [NSString stringWithFormat:@"%@\n%@", error.localizedDescription, body];
+        } else {
+          errorDescription = error.localizedDescription;
+        }
       }
       dispatch_semaphore_signal(sema);
     }] resume];


### PR DESCRIPTION
If there is a body of an error response for the manifest, include it in the description.